### PR TITLE
Passthrough fields update

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ vars:
     issue_comment_pass_through_columns: [issue_comment_body, issue_comment_created_at]
     issue_merged_pass_through_columns: [issue_merged_commit_sha, issue_merged_actor_id]
     issue_pass_through_columns: [cool_custom_issue_field, im_an_issue_too]
+    pull_request_review_pass_through_columns: [pull_request_review_body]
+    pull_request_pass_through_columns: [pull_request_base_label, pull_request_head_ref]
+    repository_pass_through_columns: [repository_language, repository_fork, repository_description]
+    requested_reviewer_history_pass_through_columns: [requested_reviewer_history_actor]
+    user_pass_through_columns: [user_hireable, one_more_user_field, im_the_last_user_field]
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ This package includes all source columns defined in the `generate_columns.sql` m
 ...
 vars:
   github_source:
-    issue_assignee_pass_through_columns: [issue_assignee_custom_field_1, issue_assignee_custom_field_2]
     issue_closed_history_pass_through_columns: [my_issue_closed_history_custom_field]
-    issue_comment_pass_through_columns: [issues_comment_on_custom_fields_too]
-    issue_label_pass_through_columns: [label_issues_with_this_column, label_maker_column, woohoo_im_a_column_too]
+    issue_comment_pass_through_columns: [issue_comment_body, issue_comment_created_at]
+    issue_merged_pass_through_columns: [issue_merged_commit_sha, issue_merged_actor_id]
+    issue_pass_through_columns: [cool_custom_issue_field, im_an_issue_too]
+
 ```
 
 ## Database support

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'github_source'
-version: '0.1.0'
+version: '0.2.0'
 
 require-dbt-version: [">=0.18.0", "<0.19.0"]
 
@@ -24,12 +24,10 @@ vars:
         repository: "{{ source('github', 'repository') }}"
         requested_reviewer_history: "{{ source('github', 'requested_reviewer_history') }}"
         user: "{{ source('github', 'user') }}"
-        issue_assignee_pass_through_columns: []
         issue_closed_history_pass_through_columns: []
         issue_comment_pass_through_columns: []
-        issue_label_pass_through_columns: []
         issue_merged_pass_through_columns: []
-        issue_pass_through_columns: []
+        issue_pass_through_columns: [] 
         pull_request_review_pass_through_columns: []
         pull_request_pass_through_columns: []
         repository_pass_through_columns: []

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'github_source_integration_tests'
-version: '0.1.0'
+version: '0.2.0'
 config-version: 2
 
 profile: 'integration_tests'

--- a/models/stg_github__issue_assignee.sql
+++ b/models/stg_github__issue_assignee.sql
@@ -19,12 +19,6 @@ with issue_assignee as (
             )
         }}
 
-        --The below script allows for pass through columns.
-        {% if var('issue_assignee_pass_through_columns') %}
-        ,
-        {{ var('issue_assignee_pass_through_columns') | join (", ")}}
-
-        {% endif %}
     from issue_assignee
 
 ), fields as (
@@ -32,14 +26,6 @@ with issue_assignee as (
     select 
       issue_id,
       user_id
-
-      --The below script allows for pass through columns.
-      {% if var('issue_assignee_pass_through_columns') %}
-      ,
-      {{ var('issue_assignee_pass_through_columns') | join (", ")}}
-
-      {% endif %}
-
     from macro
 )
 

--- a/models/stg_github__issue_label.sql
+++ b/models/stg_github__issue_label.sql
@@ -19,12 +19,6 @@ with issue_label as (
             )
         }}
 
-        --The below script allows for pass through columns.
-        {% if var('issue_label_pass_through_columns') %}
-        ,
-        {{ var('issue_label_pass_through_columns') | join (", ")}}
-
-        {% endif %}
     from issue_label
 
 ), fields as (
@@ -32,14 +26,6 @@ with issue_label as (
     select 
       issue_id,
       label
-
-      --The below script allows for pass through columns.
-      {% if var('issue_label_pass_through_columns') %}
-      ,
-      {{ var('issue_label_pass_through_columns') | join (", ")}}
-
-      {% endif %}
-
     from macro
 )
 


### PR DESCRIPTION
This pull request contains the following changes to be merged:

- Removal of any reference to ```issue_label``` and ```issue_assignee``` passthrough columns. These were the only tables determined to be removed as the model already contained every standard field and there are no custom field options.

- Update of version reference in ```dbt_project.yml``` and ```integration_tests/dbt_project.yml``` to reflect the release version of ```0.2.0```.