### PR TITLE
Bugfix/timestamp casts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# dbt_github_source v0.4.1
+
+## Fixes
+- Added the `{{ dbt_utils.type_timestamp() }}` cast function to timestamp fields within the staging models. This is required for Redshift users that have the fields originally synced as `timestamptz`. Without the casting of fields the downstream date functions will fail. ([#19](https://github.com/fivetran/dbt_github_source/pull/19))
+
 # dbt_github_source v0.4.0
 🎉 dbt v1.0.0 Compatibility 🎉
 ## 🚨 Breaking Changes 🚨

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'github_source'
-version: '0.4.0'
+version: '0.4.1'
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'github_source_integration_tests'
-version: '0.3.0'
+version: '0.4.1'
 config-version: 2
 
 profile: 'integration_tests'

--- a/models/stg_github__issue.sql
+++ b/models/stg_github__issue.sql
@@ -26,8 +26,8 @@ with issue as (
     select 
       id as issue_id,
       body,
-      closed_at,
-      created_at,
+      cast(closed_at as {{ dbt_utils.type_timestamp() }}) as closed_at,
+      cast(created_at as {{ dbt_utils.type_timestamp() }}) as created_at,
       locked as is_locked,
       milestone_id,
       number as issue_number,
@@ -35,7 +35,7 @@ with issue as (
       repository_id,
       state,
       title,
-      updated_at,
+      cast(updated_at as {{ dbt_utils.type_timestamp() }}) as updated_at,
       user_id
       
     from macro

--- a/models/stg_github__issue_closed_history.sql
+++ b/models/stg_github__issue_closed_history.sql
@@ -25,7 +25,7 @@ with issue_closed_history as (
 
     select 
       issue_id,
-      updated_at,
+      cast(updated_at as {{ dbt_utils.type_timestamp() }}) as updated_at,
       closed as is_closed
 
     from macro

--- a/models/stg_github__issue_merged.sql
+++ b/models/stg_github__issue_merged.sql
@@ -25,7 +25,7 @@ with issue_merged as (
 
     select 
       issue_id,
-      merged_at
+      cast(merged_at as {{ dbt_utils.type_timestamp() }}) as merged_at
 
     from macro
 )

--- a/models/stg_github__pull_request_review.sql
+++ b/models/stg_github__pull_request_review.sql
@@ -26,7 +26,7 @@ with pull_request_review as (
     select 
       id as pull_request_review_id,
       pull_request_id,
-      submitted_at,
+      cast(submitted_at as {{ dbt_utils.type_timestamp() }}) as submitted_at,
       state,
       user_id
 

--- a/models/stg_github__requested_reviewer_history.sql
+++ b/models/stg_github__requested_reviewer_history.sql
@@ -25,7 +25,7 @@ with requested_reviewer_history as (
 
     select 
       pull_request_id,
-      created_at,
+      cast(created_at as {{ dbt_utils.type_timestamp() }}) as created_at,
       requested_id,
       removed
 


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Fivetran created PR

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package -->
A customer identified that date functions in the dbt_github dbt package fail for Redshift users as the timestamp fields are being synced as `timestamptz` instead of `timestamp`. This is a similar issue we have seen in other packages and the route to resolve the issue is to cast the fields within the source package to reflect the more accurate `timestamp` field for Redshift users. For cross dbt functionality we will use the dbt_util.

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [ ] Yes (please provide breaking change details below.)
- [X] No  (please provide explanation how the change is non breaking below.)

This update will be an under the hood change where we simply cast the timestamp fields as a dbt_utils.timestamp() in order to account for Fivetran Redshift users experiencing the timestamp fields being synced as `timestamptz` and failing during date functions in downstream transformations.

**Is this PR in response to a previously created Issue**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [X] Yes, Issue [#25](https://github.com/fivetran/dbt_github/issues/25)
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
- [X] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [ ] Other (please provide additional testing details below)

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
- [X] BigQuery
- [X] Redshift
- [X] Snowflake
- [X] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
⌚ 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
